### PR TITLE
chore: update @adonisjs/redis peer dependency range to allow v11

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         node-version: [24]
         postgres-version: [11]
+        redis-version: [10, 11]
     services:
       postgres:
         image: postgres:${{ matrix.postgres-version }}
@@ -43,6 +44,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install
         run: npm install
+      - name: Install @adonisjs/redis v${{ matrix.redis-version }}
+        run: npm install --no-save @adonisjs/redis@${{ matrix.redis-version }}
       - name: Run Postgres Tests
         run: npm run test:pg
 
@@ -53,6 +56,7 @@ jobs:
       matrix:
         mysql: [{ version: '8.0', command: 'mysql' }]
         node-version: [24]
+        redis-version: [10, 11]
     services:
       mysql:
         image: mysql:${{ matrix.mysql.version }}
@@ -80,6 +84,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install
         run: npm install
+      - name: Install @adonisjs/redis v${{ matrix.redis-version }}
+        run: npm install --no-save @adonisjs/redis@${{ matrix.redis-version }}
       - name: Run Mysql Tests
         run: npm run test:${{ matrix.mysql.command }}
 
@@ -88,6 +94,7 @@ jobs:
     strategy:
       matrix:
         node-version: [24]
+        redis-version: [10, 11]
     services:
       redis:
         image: redis
@@ -105,5 +112,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install
         run: npm install
+      - name: Install @adonisjs/redis v${{ matrix.redis-version }}
+        run: npm install --no-save @adonisjs/redis@${{ matrix.redis-version }}
       - name: Run SQLite Tests
         run: npm run test:sqlite

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@adonisjs/core": "^7.0.0-next.1 || ^7.0.0",
     "@adonisjs/i18n": "^3.0.0-next.0 || ^3.0.0",
     "@adonisjs/lucid": "^22.0.0-next.0 || ^22.0.0",
-    "@adonisjs/redis": "^10.0.0-next.1 || ^10.0.0"
+    "@adonisjs/redis": "^10.0.0-next.1 || ^10.0.0 || ^11.0.0"
   },
   "peerDependenciesMeta": {
     "@adonisjs/assembler": {


### PR DESCRIPTION
## What

Widens the optional `@adonisjs/redis` peer dependency range from
`^10.0.0-next.1 || ^10.0.0` to `^10.0.0-next.1 || ^10.0.0 || ^11.0.0`.

Today apps that have moved to `@adonisjs/redis@11` cannot install
`@adonisjs/limiter@3.0.1` without a package manager override, even though the
package works fine against v11.

## Why no code change is needed

`@adonisjs/redis@11` is a major only because it upgrades `ioredis` to v6
(RESP3 by default, exponential-backoff retry strategy, TCP keepAlive) and
raises `engines.node` to `>= 24`.

This package never imports from `ioredis` — it is not in `dependencies`,
`devDependencies` or `peerDependencies`, and there is no `import ... from
'ioredis'` anywhere in `src/`, `providers/`, `services/` or the type
definitions. The complete set of symbols consumed from `@adonisjs/redis` is:

| Symbol | Where |
| --- | --- |
| `RedisConnection` (type) | `src/stores/redis.ts`, `tests/helpers.ts` |
| `RedisClusterConnection` (value, `instanceof` + `.nodes('master')`) | `src/stores/redis.ts` |
| `.ioConnection` | `src/stores/redis.ts` — passed as `storeClient` to `RateLimiterRedis` |
| `.flushdb()` | `src/stores/redis.ts` |
| `RedisConnections` (type) | `src/define_config.ts` |
| `@adonisjs/redis/redis_provider` (types reference) | `src/define_config.ts` |
| `RedisManager` | `tests/helpers.ts` |

All of these are `@adonisjs/redis`'s own wrapper surface and are unchanged
between v10 and v11.

The one place an ioredis object crosses a boundary is `storeClient:
client.ioConnection`, handed to `rate-limiter-flexible`'s `RateLimiterRedis`.
`rate-limiter-flexible` duck-types that client (ioredis is only a
`devDependency` there, with no peer constraint), and the two things it
branches on still behave the same under ioredis 6:

- `client.constructor.name === 'Commander'` (its node-redis detection) is
  still false for ioredis 6 `Redis` and `Cluster` instances, so it keeps
  taking the ioredis code path.
- `multi().exec()` still resolves to the ioredis `[[err, value], ...]` shape
  under RESP3 — verified against a live server with `protocol: 3` active.
- `rejectIfRedisNotReady` reads `client.status`, which ioredis 6 still exposes.

On `engines`: `@adonisjs/redis@11` requires Node.js `>= 24`, but so does
`@adonisjs/core@7`, which is already a *required* peer of this package. So v11
adds no new runtime constraint for limiter users, and CI here is already on
Node 24.

## How it was tested

- Node.js v24.20.0, Redis server 8.10.1 (Docker, matching the unpinned `redis`
  image used in `checks.yml`), `@adonisjs/redis@11.0.0` → `ioredis@6.0.0`,
  `rate-limiter-flexible@9.1.1`.
- `npm run test:pg` (Postgres 11), `npm run test:mysql` (MySQL 8.0) and
  `npm run test:sqlite` — **128/128 passing on each**, including the 23
  `tests/stores/redis.spec.ts` cases.
- `npm run typecheck` and `npm run lint` — clean.
- Same suites were run first against `@adonisjs/redis@10.0.2` / `ioredis@5.11.1`
  as a baseline: identical 128/128 result, so there is no behavioural
  difference between the two majors for this package.
- Both majors are now covered by CI on every push (see below), so this is no
  longer only a local result.

The change is additive and backward compatible — v10 (and the `10.0.0-next.1`
prerelease spelling) remain accepted.

## CI now proves both bounds

Rather than leave the widened range as an untested claim, `checks.yml` gained a
`redis-version: [10, 11]` matrix dimension on the `test-postgres`, `test-mysql`
and `test-sqlite` jobs. Each leg runs the usual `npm install` and then pins the
major under test:

```yaml
- name: Install @adonisjs/redis v${{ matrix.redis-version }}
  run: npm install --no-save @adonisjs/redis@${{ matrix.redis-version }}
```

`--no-save` keeps `package.json` untouched, and there is no lockfile to
regenerate (`.npmrc` sets `package-lock=false`) — so `devDependencies` stays at
`^10.0.0` and the manifest diff remains the single peer-range line. Making the
install explicit on *both* legs also means the v10 leg is pinned rather than
implicitly inherited from whatever `devDependencies` happens to resolve to.

The workflow diff is purely additive (+9 lines, no restructuring), but it does
take the test jobs from 3 to 6. If you'd rather not spend the extra runners:
the Redis store is independent of the SQL database, so keeping the dimension on
`test-sqlite` only — and reverting `test-postgres` / `test-mysql` to a single
leg — would still cover both majors. Happy to trim it that way if you prefer.

